### PR TITLE
Restructure the SMS helper function and add Teli support

### DIFF
--- a/sms/hook/sms_hook_flowroute.php
+++ b/sms/hook/sms_hook_flowroute.php
@@ -8,7 +8,7 @@ require_once "../sms_hook_common.php";
 if (check_acl()) {
 	if  ($_SERVER['CONTENT_TYPE'] == 'application/json') {
 		$data = json_decode(file_get_contents("php://input"));
-		route_and_send_sms($data);	
+		route_and_send_sms($data->from, $data->to, $data->body);	
 	} else {
 	  die("no");
 	}

--- a/sms/hook/sms_hook_teli.php
+++ b/sms/hook/sms_hook_teli.php
@@ -1,0 +1,13 @@
+<?php
+
+include "../root.php";
+
+require_once "resources/require.php";
+require_once "../sms_hook_common.php";
+
+if(check_acl()) { // IP whitelisting sucks, we should get proper auth like tokens or something
+		route_and_send_sms($_POST['source'], $_POST['destination'], $_POST['body']);
+} else {
+	error_log('ACCESS DENIED [SMS]: ' .  print_r($_SERVER['REMOTE_ADDR'], true));
+	die("access denied");
+}

--- a/sms/hook/sms_hook_twilio.php
+++ b/sms/hook/sms_hook_twilio.php
@@ -8,11 +8,7 @@ require_once "../sms_hook_common.php";
 if (check_acl()) {
 	if  ($_SERVER['REQUEST_METHOD'] == 'POST') {
 			error_log('REQUEST: ' .  print_r($_REQUEST, true));
-			$data = (object) ['body' => $_REQUEST['Body'],
-				'to' => str_replace("+", "", $_REQUEST['To']),
-				'from' => intval(str_replace("+", "", $_REQUEST['From']))
-				];
-		route_and_send_sms($data);
+		route_and_send_sms($_REQUEST['From'], $_REQUEST['To'], $_REQUEST['Body']);
 	} else {
 	  die("no");
 	}

--- a/sms/sms_hook_common.php
+++ b/sms/sms_hook_common.php
@@ -51,12 +51,12 @@ require_once "resources/require.php";
 }
 */
 
-function route_and_send_sms($data) {
+function route_and_send_sms($to, $from, $body) {
 	global $db, $debug, $domain_uuid, $domain_name;
 	if ($debug) {
-		error_log('DATA: ' .  print_r($data, true));
+		error_log('DATA: ' .  print_r($to, true));
 	}
-	
+
 	//create the even socket connection and send the event socket command
 		$fp = event_socket_create($_SESSION['event_socket_ip_address'], $_SESSION['event_socket_port'], $_SESSION['event_socket_password']);
 		if (!$fp) {
@@ -65,13 +65,13 @@ function route_and_send_sms($data) {
 		}
 		else {
 
-				$to = intval(preg_replace('/(^[1])/','', $data->to));
-				$from = intval($data->from);
+				$to = intval(preg_replace('/(^[1])/','', $to));
+				$from = intval($from);
 				if ($debug) {
 					error_log("TO: " . print_r($to,true));
 					error_log("FROM: " . print_r($from,true));
 				}
-				
+
 				$sql = "select domain_name, ";
 				$sql .= "dialplan_detail_data, ";
 				$sql .= "v_domains.domain_uuid as domain_uuid ";
@@ -121,14 +121,14 @@ function route_and_send_sms($data) {
 					foreach ($result as &$row) {
 						$switch_cmd = "api luarun app.lua sms inbound ";
 						$switch_cmd .= $row['destination_number'] . "@" . $domain_name;
-						$switch_cmd .= " " . $from . " '" . $data->body . "'";
+						$switch_cmd .= " " . $from . " '" . $body . "'";
 						if ($debug) {
 							error_log(print_r($switch_cmd,true));
 						}
 						$result2 = trim(event_socket_request($fp, $switch_cmd));
 					}
 				} else {
-					$switch_cmd = "api luarun app.lua sms inbound " . $match[0] . "@" . $domain_name . " " . $from . " '" . $data->body . "'";
+					$switch_cmd = "api luarun app.lua sms inbound " . $match[0] . "@" . $domain_name . " " . $from . " '" . $body . "'";
 					if ($debug) {
 						error_log(print_r($switch_cmd,true));
 					}
@@ -137,8 +137,8 @@ function route_and_send_sms($data) {
 				if ($debug) {
 					error_log("RESULT: " . print_r($result2,true));
 				}
-				
-				unset ($prep_statement);		
+
+				unset ($prep_statement);
 		}
 }
 ?>

--- a/sms/sms_hook_common.php
+++ b/sms/sms_hook_common.php
@@ -51,7 +51,7 @@ require_once "resources/require.php";
 }
 */
 
-function route_and_send_sms($to, $from, $body) {
+function route_and_send_sms($from, $to, $body) {
 	global $db, $debug, $domain_uuid, $domain_name;
 	if ($debug) {
 		error_log('DATA: ' .  print_r($to, true));


### PR DESCRIPTION
I've re-structured the `route_and_send_sms()` function to accept 3 arguments: from, to and message body instead of an object. This means the Flowroute hook is slightly larger but the Twilio and Teli hooks aren't building an object to look like Flowroute's. I'd like people with Twilio and Flowroute access to test it, ~~working on a Teli hook for this~~ (Teli hook in place, not fully tested).