### PR TITLE
Update index.lua

### DIFF
--- a/sms/resources/install/scripts/app/sms/index.lua
+++ b/sms/resources/install/scripts/app/sms/index.lua
@@ -90,7 +90,7 @@
 		event:addHeader("from", "sip:" .. from);
 		event:addHeader("from_user", from);
 		event:addHeader("from_host", domain_name);
-		event:addHeader("from_full", "sip:" .. from);
+		event:addHeader("from_full", "sip:" .. from .."@".. domain_name);
 		event:addHeader("sip_profile","internal");
 		event:addHeader("to", to);
 		event:addHeader("to_user", extension);


### PR DESCRIPTION
On line 93 changes made.
Before:-
event:addHeader("from_full", "sip:" .. from);
After:-
event:addHeader("from_full", "sip:" .. from .."@".. domain_name);

When App or any application receiving incoming SMS then it was coming only with number when try to reply on same SMS it was not going because domain name not available. Also when using Linphone and incoming SMS coming then App crashed because from Domain was blank.

After adding this all fixed and able to reply from window.