### PR TITLE
Fix Search for 'sip_force_expires'

### DIFF
--- a/bulk_account_settings/bulk_account_settings_extensions.php
+++ b/bulk_account_settings/bulk_account_settings_extensions.php
@@ -60,7 +60,7 @@
 		$sql_mod .= "or accountcode ILIKE '%".$search."%' ";		
 		$sql_mod .= "or call_group ILIKE '%".$search."%' ";
 		$sql_mod .= "or description ILIKE '%".$search."%' ";
-		if (($option_selected == "") or ($option_selected == 'call_group') or ($option_selected == 'accountcode')) {} else {
+		if (($option_selected == "") or ($option_selected == 'call_group') or ($option_selected == 'accountcode') or ($option_selected == 'sip_force_expires')) {} else {
 			$sql_mod .= "or ".$option_selected." ILIKE '%".$search."%' ";
 		}
 		$sql_mod .= ") ";


### PR DESCRIPTION
sip_force_expires is numeric so the ILIKE search didn't work correctly. This is a temp fix. Ideally the sip_force_expire value should cast as TEXT and then searched up.