### PR TITLE
Allow for extra digit

### DIFF
--- a/mobile-twinning/index.lua
+++ b/mobile-twinning/index.lua
@@ -157,7 +157,7 @@
 					sql = "SELECT uuid, call_uuid, hostname FROM channels ";
 					sql = sql .. "WHERE callstate = 'ACTIVE' ";
 					sql = sql .. "AND direction = 'outbound' ";
-					sql = sql .. "AND dest = '" .. mobile_twinning_number .. "' ";
+					sql = sql .. "AND dest like '%" .. mobile_twinning_number .. "' ";
 					sql = sql .. "AND context = '" .. domain_name .. "' ";
 					sql = sql .. "AND call_uuid IS NOT NULL ";
 				if (debug["sql"]) then


### PR DESCRIPTION
Some trunks will prepend digits to the destination like a '1'. This changes allows for a wild card match.