### PR TITLE
Fix Page Formatting

### DIFF
--- a/sessiontalk/index.php
+++ b/sessiontalk/index.php
@@ -170,8 +170,6 @@
 		echo "<img src=\"data:image/jpeg;base64,".base64_encode($image)."\" style='margin-top: 30px; padding: 5px; background: white; max-width: 100%;'>\n";
 	}
 
-	echo "</div>\n";
-
 //add the footer
 	require_once "resources/footer.php";
 


### PR DESCRIPTION
Remove an extra HTML tag that was causing the footer to display improperly.